### PR TITLE
import all branches w/ subdirectory prefix

### DIFF
--- a/load_branches_from_remote.sh
+++ b/load_branches_from_remote.sh
@@ -2,23 +2,26 @@
 
 # Delete all local branches and create all non-remote-tracking branches of a specified remote
 #
-# Usage: load_branches_from_remote.sh <remote-name>
+# Usage: load_branches_from_remote.sh <remote-name> <branch-prefix> [--master]
 #
-# Example: load_branches_from_remote.sh origin
+# Example: load_branches_from_remote.sh origin packages/package-a --master
 
 REMOTE=$1
+PREFIX=$2
+INCLUDE_MASTER=${@:3}
+
 echo "Loading all branches from the remote '$REMOTE' (all local branches are deleted)"
-# Checking out orphan commit so it 's possible to delete current branch
-git checkout --orphan void
-# Delete all local branches
-for BRANCH in `git branch`; do
-    git branch -D $BRANCH
-done
 # Create non-remote-tracking branches from selected remote
 for REMOTE_BRANCH in $(git branch -r|grep $REMOTE/); do
     BRANCH=${REMOTE_BRANCH/$REMOTE\//}
-    git branch -q $BRANCH $REMOTE_BRANCH
-    git branch --unset-upstream $BRANCH
+
+    if [ "$BRANCH" == "master" ] && [ "$INCLUDE_MASTER" == "--master" ]; then
+        git branch -q $BRANCH $REMOTE_BRANCH
+        git branch --unset-upstream $BRANCH
+    elif [ "$BRANCH" != "master" ]; then
+        git branch -q $PREFIX--$BRANCH $REMOTE_BRANCH
+        git branch --unset-upstream $PREFIX--$BRANCH
+    fi
 done
 git checkout -f master
 

--- a/monorepo_build.sh
+++ b/monorepo_build.sh
@@ -52,6 +52,8 @@ for PARAM in $@; do
     # Wipe the back-up of original history
     $MONOREPO_SCRIPT_DIR/original_refs_wipe.sh
 done
+# Delete unprefixed tags
+git for-each-ref 'refs/tags/v*' --format='%(refname:short)' | xargs git tag -d
 # Merge all master branches
 COMMIT_MSG="merge multiple repositories into a monorepo"$'\n'$'\n'"- merged using: 'monorepo_build.sh $@'"$'\n'"- see https://github.com/shopsys/monorepo-tools"
 git checkout master

--- a/rewrite_history_into.sh
+++ b/rewrite_history_into.sh
@@ -14,9 +14,9 @@ REV_LIST_PARAMS=${@:2}
 echo "Rewriting history into a subdirectory '$SUBDIRECTORY'"
 # All paths in the index are prefixed with a subdirectory and the index is updated
 # Previous index file is replaced by a new one (otherwise each file would be in the index twice)
-# The tags are rewritten as well as commits (the "cat" command will use original name without any change)
-SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' git filter-branch \
+# The tags are rewritten as well and prefixed with $SUBDIRECTORY@
+SUBDIRECTORY=$SUBDIRECTORY SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' git filter-branch \
     --index-filter '
     git ls-files -s | sed "s-$TAB\"*-&$SUBDIRECTORY_SED/-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && if [ -f "$GIT_INDEX_FILE.new" ]; then mv "$GIT_INDEX_FILE.new" "$GIT_INDEX_FILE"; fi' \
-    --tag-name-filter 'cat' \
+    --tag-name-filter 'cut -c 2- | echo $SUBDIRECTORY@$(cat -)' \
     -- $REV_LIST_PARAMS


### PR DESCRIPTION
Fixed up branch import so that all branches are imported from all repos, with prefixes to avoid branch conflicts. I'd like explain in-line the changes I made to double-check that it makes sense to other people as well.

I've tested this a lot on smaller repos (I created a small monorepo from goabstract/abstract-sdk and goabstract-eslint-config), and just did a big import of core, desktop, and web just now and things look good.
